### PR TITLE
fix: implement client-side voice filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.2 - Unreleased
 ### Fixed
 - Voice ID resolution respects `--voice-id` and avoids misclassifying long names; `--rate` now overrides `--speed` validation. (#7, thanks @joelbdavies)
+- Voice name matching now uses exact/substring checks without falling back to unrelated voices; voice search is handled client-side. (#8, thanks @joelbdavies)
 
 ## 0.2.1 - 2026-01-01
 ### Fixed

--- a/cmd/voices_test.go
+++ b/cmd/voices_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/steipete/sag/internal/elevenlabs"
 )
 
 func TestVoicesCommand(t *testing.T) {
@@ -41,6 +43,22 @@ func TestVoicesCommand(t *testing.T) {
 	// reset args to avoid polluting other tests
 	rootCmd.SetArgs(nil)
 	_ = os.Unsetenv("ELEVENLABS_API_KEY")
+}
+
+func TestFilterVoicesByName(t *testing.T) {
+	voices := []elevenlabs.Voice{
+		{VoiceID: "id1", Name: "Sarah"},
+		{VoiceID: "id2", Name: "Roger - Casual"},
+		{VoiceID: "id3", Name: "ROGUE"},
+	}
+
+	filtered := filterVoicesByName(voices, "rog")
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 voices, got %d", len(filtered))
+	}
+	if filtered[0].VoiceID != "id2" || filtered[1].VoiceID != "id3" {
+		t.Fatalf("unexpected filter order: %+v", filtered)
+	}
 }
 
 func captureStdoutVoices(t *testing.T) (restore func(), read func() string) {

--- a/internal/elevenlabs/client.go
+++ b/internal/elevenlabs/client.go
@@ -47,18 +47,13 @@ type listVoicesResponse struct {
 	Next   *string `json:"next_page_token,omitempty"`
 }
 
-// ListVoices fetches voices; search filters by name substring when provided.
-func (c *Client) ListVoices(ctx context.Context, search string) ([]Voice, error) {
+// ListVoices fetches available voices.
+func (c *Client) ListVoices(ctx context.Context) ([]Voice, error) {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
 	}
 	u.Path = path.Join(u.Path, "/v1/voices")
-	if search != "" {
-		q := u.Query()
-		q.Set("search", search)
-		u.RawQuery = q.Encode()
-	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/internal/elevenlabs/client_test.go
+++ b/internal/elevenlabs/client_test.go
@@ -23,21 +23,18 @@ func TestListVoices(t *testing.T) {
 		if r.URL.Path != "/v1/voices" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		if search := r.URL.Query().Get("search"); search != "roger" {
-			t.Fatalf("expected search query 'roger', got %q", search)
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"voices":[{"voice_id":"id1","name":"Roger","category":"premade"}]}`))
+		_, _ = w.Write([]byte(`{"voices":[{"voice_id":"id1","name":"Sarah","category":"premade"},{"voice_id":"id2","name":"Roger","category":"premade"}]}`))
 	}))
 	defer srv.Close()
 
 	c := NewClient("key", srv.URL)
-	voices, err := c.ListVoices(context.Background(), "roger")
+	voices, err := c.ListVoices(context.Background())
 	if err != nil {
 		t.Fatalf("ListVoices error: %v", err)
 	}
-	if len(voices) != 1 || voices[0].VoiceID != "id1" {
-		t.Fatalf("unexpected voices: %+v", voices)
+	if len(voices) != 2 {
+		t.Fatalf("expected 2 voices, got: %+v", voices)
 	}
 }
 


### PR DESCRIPTION
The v1/voices API does not support the search query parameter, so searching for a voice by name (e.g., -v sarah) would return all voices and then incorrectly use the first unrelated voice as a "closest match".

Changes:
- ListVoices now filters results client-side by name substring
- resolveVoice checks for exact match first, then substring match
- Returns an error if no matching voice found instead of using an unrelated voice
- Updated tests to verify actual name matching (not just first result)