### PR TITLE
Fix shell completions by recognizing Cobra's internal commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,8 @@ func maybeDefaultToSpeak() {
 
 func isCobraBuiltin(name string) bool {
 	name = strings.ToLower(name)
-	return name == "help" || name == "completion"
+	return name == "help" || name == "completion" ||
+		name == "__complete" || name == "__completenodesc"
 }
 
 func isKnownSubcommand(name string) bool {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -43,6 +43,8 @@ func TestMaybeDefaultToSpeak_Builtins(t *testing.T) {
 	cases := [][]string{
 		{"sag", "help"},
 		{"sag", "completion"},
+		{"sag", "__complete"},
+		{"sag", "__completeNoDesc"},
 	}
 	for _, args := range cases {
 		t.Run(args[1], func(t *testing.T) {


### PR DESCRIPTION
## Summary
Shell completions generated by `sag completion fish|bash|zsh` weren't working because `maybeDefaultToSpeak()` was intercepting Cobra's internal completion commands (`__complete` and `__completeNoDesc`).

## The problem
When you type `sag speak -v <TAB>`, the shell runs something like:
```
sag __complete speak -v ""
```

But `maybeDefaultToSpeak()` didn't recognize `__complete` as a builtin, so it rewrote this to:
```
sag speak __complete speak -v ""
```

Which breaks completions entirely.

## The fix
Add `__complete` and `__completeNoDesc` to `isCobraBuiltin()` so they pass through to Cobra's completion handler.

## Test plan
- [x] Added test cases for `__complete` and `__completeNoDesc`
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)