### PR TITLE
Add MiniMax TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# sag 🗣️ — “Mac-style speech with ElevenLabs”
+# sag 🗣️ — “Mac-style speech with ElevenLabs and MiniMax”
 
-One-liner TTS that works like `say`: stream to speakers by default, list voices, or save audio files.
+One-liner TTS that works like `say`: stream to speakers by default, list voices, or save audio files. Defaults to ElevenLabs, with MiniMax available via `speech-*` model IDs.
 
 ## Install
 Homebrew (macOS):
@@ -15,18 +15,20 @@ go install ./cmd/sag
 Requires Go 1.24+.
 
 ## Configuration
-- `ELEVENLABS_API_KEY` (required)
-- `--api-key-file` or `ELEVENLABS_API_KEY_FILE`/`SAG_API_KEY_FILE` to load the key from a file
-- Optional defaults: `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`
+- ElevenLabs: `ELEVENLABS_API_KEY` (or `SAG_API_KEY`)
+- MiniMax: `MINIMAX_API_KEY` (or `SAG_API_KEY`)
+- `--api-key-file` or `ELEVENLABS_API_KEY_FILE`/`MINIMAX_API_KEY_FILE`/`SAG_API_KEY_FILE` to load the key from a file
+- Optional defaults: `ELEVENLABS_VOICE_ID`, `MINIMAX_VOICE_ID`, or `SAG_VOICE_ID`
+- Optional: `MINIMAX_API_HOST` or `MINIMAX_BASE_URL` to override the MiniMax base URL
 
 ## Usage
 
 Features:
 - macOS `say`-style default: `sag "Hello"` routes to `speak` automatically.
 - Streaming playback to speakers with optional file output.
-- Voice discovery via `sag voices` and `-v ?`.
+- Voice discovery via `sag voices` (ElevenLabs) and `-v ?` (provider-specific).
 - Speed/rate controls, latency tiers, and format inference from output extension.
-- Model selection via `--model-id` (defaults to `eleven_v3`; use `eleven_multilingual_v2` for a stable baseline).
+- Model selection via `--model-id` (defaults to `eleven_v3`; use `eleven_multilingual_v2` for a stable baseline, `speech-*` for MiniMax).
 
 Speak (streams audio):
 ```bash
@@ -52,6 +54,8 @@ sag speak -v Roger --stream --latency-tier 3 "Faster start"
 sag speak -v Roger --speed 1.2 "Talk a bit faster"
 sag speak -v Roger --model-id eleven_multilingual_v2 "Use stable v2 baseline"
 sag speak -v Roger --output out.wav --format pcm_44100 "Wave output"
+sag speak --model-id speech-01 -v ? "List MiniMax voices"
+sag speak --model-id speech-01 --output out.flac --stream=false "MiniMax file output"
 ```
 
 Key flags (subset):
@@ -94,7 +98,11 @@ Highlights:
 
 ## Models / engines
 
-`sag` supports any ElevenLabs `model_id` via `--model-id` (we pass it through). Practical defaults + common IDs:
+Provider selection:
+- ElevenLabs (default): any ElevenLabs `model_id` via `--model-id` (we pass it through).
+- MiniMax: use a `speech-*` model ID to route requests to MiniMax. Streaming/playback is MP3-only; use `--stream=false` for WAV/FLAC output.
+
+Practical defaults + common ElevenLabs IDs:
 
 | Engine | `--model-id` | Prompting style | Best for |
 |---|---|---|---|
@@ -123,6 +131,6 @@ Notes:
   - Build: `go build ./cmd/sag`
 
 ## Limitations
-- ElevenLabs account and API key required.
+- ElevenLabs or MiniMax account and API key required (per provider).
 - Voice defaults to first available if not provided.
 - Non-mac platforms: playback still works via `go-mp3` + `oto`, but device selection flags are no-ops.

--- a/cmd/api_key.go
+++ b/cmd/api_key.go
@@ -26,10 +26,59 @@ func ensureAPIKey() error {
 	return nil
 }
 
+func ensureAPIKeyForProvider(provider string) error {
+	if provider == "minimax" {
+		return ensureMiniMaxAPIKey()
+	}
+	return ensureAPIKey()
+}
+
+func ensureMiniMaxAPIKey() error {
+	if cfg.APIKey == "" {
+		key, err := resolveMiniMaxAPIKeyFromFile()
+		if err != nil {
+			return err
+		}
+		cfg.APIKey = key
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = os.Getenv("MINIMAX_API_KEY")
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = os.Getenv("SAG_API_KEY")
+	}
+	if cfg.APIKey == "" {
+		return fmt.Errorf("missing MiniMax API key (set --api-key, --api-key-file, or MINIMAX_API_KEY)")
+	}
+	return nil
+}
+
 func resolveAPIKeyFromFile() (string, error) {
 	path := cfg.APIKeyFile
 	if path == "" {
 		path = os.Getenv("ELEVENLABS_API_KEY_FILE")
+	}
+	if path == "" {
+		path = os.Getenv("SAG_API_KEY_FILE")
+	}
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read api key file: %w", err)
+	}
+	key := strings.TrimSpace(string(data))
+	if key == "" {
+		return "", fmt.Errorf("api key file %q is empty", path)
+	}
+	return key, nil
+}
+
+func resolveMiniMaxAPIKeyFromFile() (string, error) {
+	path := cfg.APIKeyFile
+	if path == "" {
+		path = os.Getenv("MINIMAX_API_KEY_FILE")
 	}
 	if path == "" {
 		path = os.Getenv("SAG_API_KEY_FILE")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/steipete/sag
 go 1.24.0
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/ebitengine/oto/v3 v3.4.0
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
 github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=

--- a/internal/minimax/client.go
+++ b/internal/minimax/client.go
@@ -1,0 +1,435 @@
+package minimax
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+const defaultBaseURL = "https://api.minimax.io"
+
+// Client talks to the MiniMax TTS API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient returns a client configured with the given API key and base URL.
+func NewClient(apiKey, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// Voice represents a MiniMax voice entry.
+type Voice struct {
+	VoiceID     string
+	Name        string
+	Category    string
+	Description string
+}
+
+type voiceEntry struct {
+	VoiceID     string   `json:"voice_id"`
+	VoiceName   string   `json:"voice_name"`
+	Description []string `json:"description,omitempty"`
+}
+
+type listVoicesRequest struct {
+	VoiceType string `json:"voice_type"`
+}
+
+type listVoicesResponse struct {
+	SystemVoice     []voiceEntry `json:"system_voice"`
+	VoiceCloning    []voiceEntry `json:"voice_cloning"`
+	VoiceGeneration []voiceEntry `json:"voice_generation"`
+	BaseResp        *baseResp    `json:"base_resp,omitempty"`
+}
+
+// ListVoices fetches available voices.
+func (c *Client) ListVoices(ctx context.Context) ([]Voice, error) {
+	u, err := c.httpURL("/v1/get_voice")
+	if err != nil {
+		return nil, err
+	}
+
+	reqBody, err := json.Marshal(listVoicesRequest{VoiceType: "all"})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list voices failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var payload listVoicesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	if err := payload.BaseResp.err(); err != nil {
+		return nil, err
+	}
+
+	voices := make([]Voice, 0, len(payload.SystemVoice)+len(payload.VoiceCloning)+len(payload.VoiceGeneration))
+	appendVoices := func(category string, entries []voiceEntry) {
+		for _, v := range entries {
+			name := strings.TrimSpace(v.VoiceName)
+			if name == "" {
+				name = v.VoiceID
+			}
+			voices = append(voices, Voice{
+				VoiceID:     v.VoiceID,
+				Name:        name,
+				Category:    category,
+				Description: strings.Join(v.Description, " "),
+			})
+		}
+	}
+	appendVoices("system", payload.SystemVoice)
+	appendVoices("voice_cloning", payload.VoiceCloning)
+	appendVoices("voice_generation", payload.VoiceGeneration)
+	return voices, nil
+}
+
+// TTSRequest configures a text-to-speech request payload.
+type TTSRequest struct {
+	Model           string
+	Text            string
+	Speed           float64
+	Volume          float64
+	Pitch           int
+	AudioFormat     string
+	SampleRate      int
+	Bitrate         int
+	Channel         int
+	LanguageBoost   string
+	ContinuousSound *bool
+}
+
+type baseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+func (b *baseResp) err() error {
+	if b == nil {
+		return nil
+	}
+	if b.StatusCode == 0 {
+		return nil
+	}
+	msg := strings.TrimSpace(b.StatusMsg)
+	if msg == "" {
+		msg = "unknown error"
+	}
+	return fmt.Errorf("minimax error: %s (code=%d)", msg, b.StatusCode)
+}
+
+type voiceSetting struct {
+	VoiceID string  `json:"voice_id"`
+	Speed   float64 `json:"speed"`
+	Vol     float64 `json:"vol"`
+	Pitch   int     `json:"pitch"`
+}
+
+type audioSetting struct {
+	Format     string `json:"format,omitempty"`
+	SampleRate int    `json:"sample_rate,omitempty"`
+	Bitrate    int    `json:"bitrate,omitempty"`
+	Channel    int    `json:"channel,omitempty"`
+}
+
+type t2aRequest struct {
+	Model           string       `json:"model"`
+	Text            string       `json:"text"`
+	Stream          bool         `json:"stream"`
+	OutputFormat    string       `json:"output_format,omitempty"`
+	VoiceSetting    voiceSetting `json:"voice_setting"`
+	AudioSetting    audioSetting `json:"audio_setting,omitempty"`
+	LanguageBoost   string       `json:"language_boost,omitempty"`
+	ContinuousSound *bool        `json:"continuous_sound,omitempty"`
+}
+
+type t2aResponse struct {
+	Data struct {
+		Audio string `json:"audio"`
+	} `json:"data"`
+	BaseResp *baseResp `json:"base_resp,omitempty"`
+}
+
+// ConvertTTS downloads the full audio before returning.
+func (c *Client) ConvertTTS(ctx context.Context, voiceID string, req TTSRequest) ([]byte, error) {
+	u, err := c.httpURL("/v1/t2a_v2")
+	if err != nil {
+		return nil, err
+	}
+
+	payload := t2aRequest{
+		Model:           req.Model,
+		Text:            req.Text,
+		Stream:          false,
+		OutputFormat:    "hex",
+		VoiceSetting:    buildVoiceSetting(voiceID, req),
+		AudioSetting:    buildAudioSetting(req),
+		LanguageBoost:   req.LanguageBoost,
+		ContinuousSound: req.ContinuousSound,
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("convert TTS failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var response t2aResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	if err := response.BaseResp.err(); err != nil {
+		return nil, err
+	}
+	if response.Data.Audio == "" {
+		return nil, errors.New("minimax response missing audio")
+	}
+
+	data, err := hex.DecodeString(response.Data.Audio)
+	if err != nil {
+		return nil, fmt.Errorf("decode audio hex: %w", err)
+	}
+	return data, nil
+}
+
+type wsTaskStart struct {
+	Event           string       `json:"event"`
+	Model           string       `json:"model"`
+	VoiceSetting    voiceSetting `json:"voice_setting"`
+	AudioSetting    audioSetting `json:"audio_setting,omitempty"`
+	LanguageBoost   string       `json:"language_boost,omitempty"`
+	ContinuousSound *bool        `json:"continuous_sound,omitempty"`
+}
+
+type wsTaskContinue struct {
+	Event string `json:"event"`
+	Text  string `json:"text"`
+}
+
+type wsMessage struct {
+	Event    string    `json:"event"`
+	Data     *wsData   `json:"data,omitempty"`
+	BaseResp *baseResp `json:"base_resp,omitempty"`
+	IsFinal  bool      `json:"is_final,omitempty"`
+}
+
+type wsData struct {
+	Audio string `json:"audio,omitempty"`
+}
+
+type cancelReadCloser struct {
+	*io.PipeReader
+	cancel func()
+}
+
+func (c *cancelReadCloser) Close() error {
+	c.cancel()
+	return c.PipeReader.Close()
+}
+
+// StreamTTS streams MP3 audio from MiniMax via WebSocket.
+func (c *Client) StreamTTS(ctx context.Context, voiceID string, req TTSRequest) (io.ReadCloser, error) {
+	wsURL, err := c.wsURL("/ws/v1/t2a_v2")
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer cancel()
+		defer func() { _ = pw.Close() }()
+
+		header := http.Header{}
+		header.Set("Authorization", "Bearer "+c.apiKey)
+		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: header})
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		defer func() {
+			_ = conn.Close(websocket.StatusNormalClosure, "done")
+		}()
+
+		if err := readWSUntilEvent(ctx, conn, "connected_success"); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+
+		start := wsTaskStart{
+			Event:           "task_start",
+			Model:           req.Model,
+			VoiceSetting:    buildVoiceSetting(voiceID, req),
+			AudioSetting:    buildAudioSetting(req),
+			LanguageBoost:   req.LanguageBoost,
+			ContinuousSound: req.ContinuousSound,
+		}
+		if err := wsjson.Write(ctx, conn, start); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := readWSUntilEvent(ctx, conn, "task_started"); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+
+		if err := wsjson.Write(ctx, conn, wsTaskContinue{Event: "task_continue", Text: req.Text}); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+
+		for {
+			var msg wsMessage
+			if err := wsjson.Read(ctx, conn, &msg); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			if err := msg.BaseResp.err(); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			if msg.Event == "task_failed" {
+				_ = pw.CloseWithError(errors.New("minimax stream failed"))
+				return
+			}
+			if msg.Data != nil && msg.Data.Audio != "" {
+				chunk, err := hex.DecodeString(msg.Data.Audio)
+				if err != nil {
+					_ = pw.CloseWithError(fmt.Errorf("decode audio chunk: %w", err))
+					return
+				}
+				if len(chunk) > 0 {
+					if _, err := pw.Write(chunk); err != nil {
+						return
+					}
+				}
+			}
+			if msg.IsFinal || msg.Event == "task_finished" {
+				return
+			}
+		}
+	}()
+
+	return &cancelReadCloser{PipeReader: pr, cancel: cancel}, nil
+}
+
+func readWSUntilEvent(ctx context.Context, conn *websocket.Conn, want string) error {
+	for {
+		var msg wsMessage
+		if err := wsjson.Read(ctx, conn, &msg); err != nil {
+			return err
+		}
+		if err := msg.BaseResp.err(); err != nil {
+			return err
+		}
+		if msg.Event == "task_failed" {
+			return errors.New("minimax task failed")
+		}
+		if msg.Event == want {
+			return nil
+		}
+	}
+}
+
+func buildVoiceSetting(voiceID string, req TTSRequest) voiceSetting {
+	return voiceSetting{
+		VoiceID: voiceID,
+		Speed:   req.Speed,
+		Vol:     req.Volume,
+		Pitch:   req.Pitch,
+	}
+}
+
+func buildAudioSetting(req TTSRequest) audioSetting {
+	return audioSetting{
+		Format:     req.AudioFormat,
+		SampleRate: req.SampleRate,
+		Bitrate:    req.Bitrate,
+		Channel:    req.Channel,
+	}
+}
+
+func (c *Client) httpURL(endpoint string) (string, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", err
+	}
+	u.Path = path.Join(u.Path, endpoint)
+	return u.String(), nil
+}
+
+func (c *Client) wsURL(endpoint string) (string, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		u.Scheme = "wss"
+	}
+	u.Path = path.Join(u.Path, endpoint)
+	return u.String(), nil
+}

--- a/internal/minimax/doc.go
+++ b/internal/minimax/doc.go
@@ -1,0 +1,2 @@
+// Package minimax provides a small client for the MiniMax TTS API.
+package minimax


### PR DESCRIPTION
  Summary
  - Add MiniMax as an optional TTS provider alongside ElevenLabs.
  - Implement a MiniMax client (HTTP + WebSocket), voice listing, and streaming/non‑streaming playback paths in speak.
  - Update README to document MiniMax env vars, provider selection via speech-* model IDs, and usage examples.

  Details
  - Provider detection routes speech-* model IDs to MiniMax.
  - MiniMax supports streaming via WebSocket (MP3 only) and non‑streaming HTTP (MP3/WAV/FLAC).
  - API key handling now includes MiniMax env vars and key file options.