### PR TITLE
Speak piped-in text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 - Unreleased
 ### Added
 - Voice discovery: semantic `--query` over name/description/labels, repeatable `--label` filters, preview playback via `--try`, metadata caching, and server-side name search when supported.
+- Bare `sag` now reads piped stdin like macOS `say`, so `echo "hello" | sag` speaks the text without requiring the `speak` subcommand. (#14, thanks @atdrendel)
 
 ## 0.2.2 - 2026-01-24
 ### Fixed

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,10 @@ func init() {
 // maybeDefaultToSpeak injects the "speak" subcommand when the user calls `sag` like macOS `say`.
 func maybeDefaultToSpeak() {
 	if len(os.Args) <= 1 {
+		// Still default to speak if stdin has piped data
+		if !isStdinTTY() {
+			os.Args = append(os.Args, "speak")
+		}
 		return
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -126,8 +126,8 @@ func TestMaybeDefaultToSpeak_PipedStdin(t *testing.T) {
 	os.Stdin = r
 	defer func() {
 		os.Stdin = origStdin
-		r.Close()
 		w.Close()
+		r.Close()
 	}()
 
 	os.Args = []string{"sag"}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -113,3 +113,33 @@ func TestExecuteHelp(t *testing.T) {
 		t.Fatalf("unreachable")
 	}
 }
+
+func TestMaybeDefaultToSpeak_PipedStdin(t *testing.T) {
+	defer keepArgs(t)()
+
+	// Replace stdin with a pipe (non-TTY)
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+		w.Close()
+	}()
+
+	os.Args = []string{"sag"}
+	maybeDefaultToSpeak()
+
+	want := []string{"sag", "speak"}
+	if len(os.Args) != len(want) {
+		t.Fatalf("expected %v, got %v", want, os.Args)
+	}
+	for i := range want {
+		if os.Args[i] != want[i] {
+			t.Fatalf("args mismatch at %d: got %q want %q", i, os.Args[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Before:

```sh
$ echo "Hallo" | ./sag
Command-line ElevenLabs TTS with macOS playback. Call it like macOS 'say': if you skip the subcommand, text args are passed to 'speak' (e.g. `sag "Hello"`).

Tip: run `sag prompting` for model-specific prompting tips.
Models: `eleven_v3` (default), `eleven_multilingual_v2` (stable), `eleven_flash_v2_5` (fast/cheap), `eleven_turbo_v2_5` (balanced).

Usage:
  sag [command]

Examples:
  sag "Hi Peter"
  echo 'piped input' | sag
  sag speak -v Roger --rate 200 "Faster speech"
  sag prompting

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  prompting   Prompting guide for better ElevenLabs speech
  speak       Speak the provided text using ElevenLabs TTS (default: stream to speakers)
  voices      List available ElevenLabs voices

Flags:
      --api-key string        ElevenLabs API key (or ELEVENLABS_API_KEY)
      --api-key-file string   Read ElevenLabs API key from file (or ELEVENLABS_API_KEY_FILE)
      --base-url string       Override ElevenLabs API base URL (default "https://api.elevenlabs.io")
  -h, --help                  help for sag
  -V, --version               Print version and exit

Use "sag [command] --help" for more information about a command.
```

After:

```sh
$ echo "Hallo" | ./sag
# Audio output: "Hallo"
```