### PR TITLE
fix: support Opus/OGG output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 - Voice discovery: semantic `--query` over name/description/labels, repeatable `--label` filters, preview playback via `--try`, metadata caching, and server-side name search when supported.
 - Bare `sag` now reads piped stdin like macOS `say`, so `echo "hello" | sag` speaks the text without requiring the `speak` subcommand. (#14, thanks @atdrendel)
+### Fixed
+- `--format` and `.ogg`/`.opus` output paths now request native ElevenLabs Opus output instead of always receiving MP3. (#16, thanks @derspotter)
 
 ## 0.2.2 - 2026-01-24
 ### Fixed

--- a/cmd/speak.go
+++ b/cmd/speak.go
@@ -535,6 +535,8 @@ func inferFormatFromExt(path string) string {
 		return "mp3_44100_128"
 	case ".wav", ".wave":
 		return "pcm_44100"
+	case ".ogg", ".opus":
+		return "opus_48000_64"
 	default:
 		return ""
 	}

--- a/cmd/speak_integration_test.go
+++ b/cmd/speak_integration_test.go
@@ -22,6 +22,9 @@ func TestSpeakCommand_FlagsBuildRequestAndMetrics(t *testing.T) {
 		if path.Base(r.URL.Path) != voiceID {
 			t.Fatalf("expected voice ID %q, got %q", voiceID, path.Base(r.URL.Path))
 		}
+		if got := r.URL.Query().Get("output_format"); got != "mp3_44100_128" {
+			t.Fatalf("expected output_format query mp3_44100_128, got %q", got)
+		}
 
 		var got map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
@@ -31,8 +34,8 @@ func TestSpeakCommand_FlagsBuildRequestAndMetrics(t *testing.T) {
 		if got["model_id"] != "eleven_v3" {
 			t.Fatalf("expected model_id eleven_v3, got %v", got["model_id"])
 		}
-		if got["output_format"] != "mp3_44100_128" {
-			t.Fatalf("expected output_format mp3_44100_128, got %v", got["output_format"])
+		if _, ok := got["output_format"]; ok {
+			t.Fatalf("expected output_format to be omitted from body, got %v", got["output_format"])
 		}
 		if got["seed"] != float64(42) {
 			t.Fatalf("expected seed 42, got %v", got["seed"])

--- a/cmd/speak_test.go
+++ b/cmd/speak_test.go
@@ -22,6 +22,8 @@ func TestInferFormatFromExt(t *testing.T) {
 		{"out.MP3", "mp3_44100_128"},
 		{"audio.wav", "pcm_44100"},
 		{"audio.WAVE", "pcm_44100"},
+		{"voice.ogg", "opus_48000_64"},
+		{"voice.OPUS", "opus_48000_64"},
 		{"audio.unknown", ""},
 	}
 	for _, tt := range tests {

--- a/internal/elevenlabs/client.go
+++ b/internal/elevenlabs/client.go
@@ -213,11 +213,15 @@ func (c *Client) StreamTTS(ctx context.Context, voiceID string, payload TTSReque
 		return nil, err
 	}
 	u.Path = path.Join(u.Path, "/v1/text-to-speech", voiceID, "stream")
+	q := u.Query()
 	if latency > 0 {
-		q := u.Query()
 		q.Set("optimize_streaming_latency", fmt.Sprint(latency))
-		u.RawQuery = q.Encode()
 	}
+	if payload.OutputFormat != "" {
+		q.Set("output_format", payload.OutputFormat)
+		payload.OutputFormat = "" // don't send in body
+	}
+	u.RawQuery = q.Encode()
 
 	bodyBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -229,7 +233,7 @@ func (c *Client) StreamTTS(ctx context.Context, voiceID string, payload TTSReque
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "audio/mpeg")
+	req.Header.Set("Accept", "*/*")
 	req.Header.Set("xi-api-key", c.apiKey)
 
 	resp, err := c.httpClient.Do(req)
@@ -253,6 +257,12 @@ func (c *Client) ConvertTTS(ctx context.Context, voiceID string, payload TTSRequ
 		return nil, err
 	}
 	u.Path = path.Join(u.Path, "/v1/text-to-speech", voiceID)
+	q := u.Query()
+	if payload.OutputFormat != "" {
+		q.Set("output_format", payload.OutputFormat)
+		payload.OutputFormat = ""
+	}
+	u.RawQuery = q.Encode()
 
 	bodyBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -264,7 +274,7 @@ func (c *Client) ConvertTTS(ctx context.Context, voiceID string, payload TTSRequ
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "audio/mpeg")
+	req.Header.Set("Accept", "*/*")
 	req.Header.Set("xi-api-key", c.apiKey)
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/elevenlabs/client_test.go
+++ b/internal/elevenlabs/client_test.go
@@ -107,8 +107,8 @@ func TestStreamTTS(t *testing.T) {
 		if !strings.Contains(r.URL.Path, "/v1/text-to-speech/voice123/stream") {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		if r.Header.Get("Accept") != "audio/mpeg" {
-			t.Fatalf("missing Accept header")
+		if r.Header.Get("Accept") != "*/*" {
+			t.Fatalf("unexpected Accept header: %q", r.Header.Get("Accept"))
 		}
 		_, _ = w.Write([]byte("audio-data"))
 	}))
@@ -135,9 +135,16 @@ func TestStreamTTS_PayloadFields(t *testing.T) {
 	seed := uint32(0)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("output_format"); got != "mp3_44100_128" {
+			t.Fatalf("expected output_format query mp3_44100_128, got %q", got)
+		}
+
 		var got map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := got["output_format"]; ok {
+			t.Fatalf("expected output_format to be omitted from body, got %v", got["output_format"])
 		}
 
 		if got["seed"] != float64(0) {
@@ -213,6 +220,9 @@ func TestConvertTTS(t *testing.T) {
 		if path.Base(r.URL.Path) != "voice123" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if r.Header.Get("Accept") != "*/*" {
+			t.Fatalf("unexpected Accept header: %q", r.Header.Get("Accept"))
+		}
 		_, _ = w.Write([]byte("full-audio"))
 	}))
 	defer srv.Close()
@@ -223,6 +233,37 @@ func TestConvertTTS(t *testing.T) {
 		t.Fatalf("ConvertTTS error: %v", err)
 	}
 	if string(data) != "full-audio" {
+		t.Fatalf("unexpected data: %q", string(data))
+	}
+}
+
+func TestConvertTTS_OutputFormatQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("output_format"); got != "opus_48000_64" {
+			t.Fatalf("expected output_format query opus_48000_64, got %q", got)
+		}
+
+		var got map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := got["output_format"]; ok {
+			t.Fatalf("expected output_format to be omitted from body, got %v", got["output_format"])
+		}
+
+		_, _ = w.Write([]byte("opus-audio"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("key", srv.URL)
+	data, err := c.ConvertTTS(context.Background(), "voice123", TTSRequest{
+		Text:         "hello",
+		OutputFormat: "opus_48000_64",
+	})
+	if err != nil {
+		t.Fatalf("ConvertTTS error: %v", err)
+	}
+	if string(data) != "opus-audio" {
 		t.Fatalf("unexpected data: %q", string(data))
 	}
 }


### PR DESCRIPTION
## Problem

The `--format` flag and `.ogg`/`.opus` file extensions are not respected — sag always outputs MP3 regardless of the requested format.

Two bugs:
1. `output_format` is sent in the JSON request body, but the [ElevenLabs API](https://elevenlabs.io/docs/api-reference/text-to-speech/convert) expects it as a **query parameter**.
2. `inferFormatFromExt()` doesn't recognize `.ogg`/`.opus` extensions.

## Fix

- Move `output_format` from JSON body to query parameter (both `StreamTTS` and `ConvertTTS`)
- Add `.ogg`/`.opus` extension inference → `opus_48000_64`
- Change `Accept` header from `audio/mpeg` to `*/*` to accept non-MP3 responses

## Use case

WhatsApp and Telegram voice notes require OGG/Opus. With this fix:
```bash
sag "Hello" -o voice.ogg   # outputs native Opus from ElevenLabs API
sag "Hello" --format opus_48000_128 -o output.opus  # also works
```

No ffmpeg conversion needed.