### PR TITLE
ci: preserve hidden Pages files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: dist/docs-site
+          include-hidden-files: true
 
       - name: Deploy
         id: deployment


### PR DESCRIPTION
## Summary

- preserve the generated `.nojekyll` file in the GitHub Pages artifact
- opt into hidden-file packaging required by `actions/upload-pages-artifact@v5`

## Root cause

The v5 action defaults `include-hidden-files` to `false`. Sag's docs builder generates `dist/docs-site/.nojekyll`, so the recent action upgrade silently excluded that file.

## Proof

- `pnpm check`
- `pnpm build`
- `pnpm docs:build`
- `actionlint .github/workflows/*.yml`
- local artifact emulation: default v5 exclusion omits `.nojekyll`; explicit opt-in includes it
- autoreview: clean, no accepted/actionable findings

Risk: low; one documented action input, limited to Pages artifact packaging.
