### PR TITLE
chore: refresh dependencies and preserve macOS compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
     branches: [ main, master ]
 
 jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Build docs site
+        run: node scripts/build-docs-site.mjs
+
   lint-test:
     runs-on: ubuntu-latest
     steps:
@@ -13,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25.x'
           check-latest: true
@@ -36,7 +50,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.2
           args: --timeout=3m
 
       - name: Test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,6 +16,11 @@ permissions:
 jobs:
   build-macos:
     runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '15.0'
+      # Explicit flags also make the deployment target part of Go's cgo cache key.
+      CGO_CFLAGS: '-O2 -g -mmacosx-version-min=15.0'
+      CGO_LDFLAGS: '-O2 -g -mmacosx-version-min=15.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -23,7 +28,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
           check-latest: true
@@ -39,6 +44,14 @@ jobs:
 
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o dist/build/sag-darwin-arm64 ./cmd/sag
           CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o dist/build/sag-darwin-amd64 ./cmd/sag
+
+          for arch in arm64 amd64; do
+            minimum="$(xcrun vtool -show-build "dist/build/sag-darwin-$arch" | awk '$1 == "minos" { print $2 }')"
+            if [[ "$minimum" != "$MACOSX_DEPLOYMENT_TARGET" ]]; then
+              echo "Unexpected macOS minimum for $arch: $minimum" >&2
+              exit 1
+            fi
+          done
 
           lipo -create -output dist/build/sag dist/build/sag-darwin-arm64 dist/build/sag-darwin-amd64
 
@@ -81,7 +94,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
           check-latest: true
@@ -122,7 +135,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
           check-latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 - Source-install documentation now requires Go 1.25+, matching `go.mod`.
+- macOS release builds now explicitly retain the existing macOS 15 minimum when the build runner or SDK changes.
+
+### Changed
+- Updated Oto to 3.4.1 and purego to 0.11.0 for upstream platform and FFI fixes; refreshed Go/Node setup and lint tooling while retaining Go 1.25+ support. CI now also verifies the docs build.
 
 ## 0.4.1 - 2026-07-01
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,6 +14,7 @@ Follow these steps for each release. Title GitHub releases as `sag <version>`.
 - Run the gates: `pnpm format && pnpm lint && pnpm test && pnpm build`.
 - Commit the release changes, then create an annotated tag: `git tag -a v<version> -m "Release <version>"`.
 - Push `main` and the tag. The `Release Binaries` workflow builds macOS arm64/amd64/universal, Linux arm64/amd64, and Windows amd64 archives, verifies their checksums, attaches them to the GitHub release, dispatches the Homebrew tap update, and waits for that workflow.
+- Keep the macOS deployment target and cgo compiler/linker flags pinned to macOS 15.0, matching the existing released minimum. The workflow verifies both architecture slices with `xcrun vtool -show-build` before packaging.
 - Watch the exact tag workflow through completion. Repair or rerun failures before continuing.
 - Verify the GitHub release:
   - title is `sag <version>`

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/steipete/sag
 go 1.25.0
 
 require (
-	github.com/ebitengine/oto/v3 v3.4.0
+	github.com/ebitengine/oto/v3 v3.4.1
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 )
 
 require (
-	github.com/ebitengine/purego v0.10.1 // indirect
+	github.com/ebitengine/purego v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
-github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
-github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
-github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/oto/v3 v3.4.1 h1:uX7B03/P2P8oWiSI5HXjyjSP4besYn3V9nDk3cR+eIY=
+github.com/ebitengine/oto/v3 v3.4.1/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
+github.com/ebitengine/purego v0.11.0 h1:jhp/D+Nyv7UUW8HAcmcjt2N2rYrYi9m3SL21k0Ua/NI=
+github.com/ebitengine/purego v0.11.0/go.mod h1:DCHPP08djqhNSoTfImcnHYQRZmd0qhakvrozqaEYhGQ=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
 github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=


### PR DESCRIPTION
Updates Oto to 3.4.1 and purego to 0.11.0, along with `setup-go` v7, `setup-node` v7, and golangci-lint 2.13.2. The source minimum stays Go 1.25.0, and CI/release builds continue using the latest Go 1.25 patch. CI now builds the docs with the same Node 24 setup used by the existing Pages workflow.

The dependency review confirmed that Oto's Darwin integration still uses compatible `Dlopen`/`RegisterLibFunc` APIs and pointer/integer AudioQueue callbacks. Purego's new Go 1.25 requirement matches sag's existing minimum. Playback proof exercises these calls through the compiled CLI.

Also preserves the released macOS 15 minimum explicitly with `MACOSX_DEPLOYMENT_TARGET=15.0` and matching cgo compiler/linker flags. Both published v0.4.1 architecture slices target macOS 15; unqualified builds on a newer host inherited macOS 26. Explicit cgo flags keep the target in Go’s build-cache inputs, and the release workflow checks both Mach-O architecture minimums before packaging. This prevents runner/SDK updates from silently raising the minimum.

Validation:
- Full tests and CLI builds on Go 1.25.0 and 1.25.14, with bounded build/test concurrency.
- golangci-lint 2.13.2, actionlint, module verification, formatting, and diff checks.
- Standalone CLI proof: help/version/prompting, both provider voice catalogs, ElevenLabs streamed/buffered file bytes, 60db WAV header/audio validation, and real silent playback through Oto and afplay. Provider responses are synthetic and served on loopback.
- Native macOS arm64 and macOS amd64 builds, plus Windows amd64 cross-build; release deployment metadata checked separately.

No release or manual deployment is part of this PR.
